### PR TITLE
Changed access to WinRT to only from worker threads

### DIFF
--- a/Plugins/WindowCapture2D/Source/WindowCapture2D/Private/CaptureMachine.cpp
+++ b/Plugins/WindowCapture2D/Source/WindowCapture2D/Private/CaptureMachine.cpp
@@ -15,7 +15,7 @@ UCaptureMachine::UCaptureMachine()
 {
 }
 
-UTexture2D* UCaptureMachine::Start()
+void UCaptureMachine::Start()
 {
 	_TickHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UCaptureMachine::TickCapture), 1.0f / static_cast<float>(Properties.FrameRate));
 	
@@ -25,8 +25,8 @@ UTexture2D* UCaptureMachine::Start()
 
 	if (Properties.CaptureTargetTitle.IsEmpty())
 	{
-		WC_LOG(Log, "CaptureTargetTitle is empty : %s", *Properties.CaptureTargetTitle);
-		return nullptr;
+		WC_LOG(Warning, "CaptureTargetTitle is empty : %s", *Properties.CaptureTargetTitle);
+		return;
 	}
 
 	::EnumWindows([](HWND hwnd, LPARAM lParam) -> BOOL
@@ -37,17 +37,11 @@ UTexture2D* UCaptureMachine::Start()
 
 	if (!m_TargetWindow || !::IsWindow(m_TargetWindow))
 	{
-		WC_LOG(Log, "Target window not found : %s", *Properties.CaptureTargetTitle);
-		return nullptr;
+		WC_LOG(Warning, "Target window not found : %s", *Properties.CaptureTargetTitle);
+		return;
 	}
 
 	m_Session->Start(m_TargetWindow);
-
-	GetWindowSize();
-	
-	ReCreateTexture();
-	
-	return TextureTarget;
 }
 
 void UCaptureMachine::Dispose()

--- a/Plugins/WindowCapture2D/Source/WindowCapture2D/Private/WindowCaptureActor.cpp
+++ b/Plugins/WindowCapture2D/Source/WindowCapture2D/Private/WindowCaptureActor.cpp
@@ -29,7 +29,7 @@ void AWindowCaptureActor::BeginDestroy()
 	}
 }
 
-UTexture2D* AWindowCaptureActor::Start()
+void AWindowCaptureActor::Start()
 {
 	if (CaptureMachine)
 	{
@@ -42,7 +42,7 @@ UTexture2D* AWindowCaptureActor::Start()
 
 	CaptureMachine->ChangeTexture.AddDynamic(this, &AWindowCaptureActor::OnChangeTexture);
 	
-	return CaptureMachine->Start();
+	CaptureMachine->Start();
 }
 
 void AWindowCaptureActor::OnChangeTexture(UTexture2D* _NewTexture)

--- a/Plugins/WindowCapture2D/Source/WindowCapture2D/Private/WindowCaptureWidget.cpp
+++ b/Plugins/WindowCapture2D/Source/WindowCapture2D/Private/WindowCaptureWidget.cpp
@@ -33,7 +33,7 @@ void UWindowCaptureWidget::BeginDestroy()
 }
 
 
-UTexture2D* UWindowCaptureWidget::Start()
+void UWindowCaptureWidget::Start()
 {
 	if (CaptureMachine)
 	{
@@ -45,7 +45,7 @@ UTexture2D* UWindowCaptureWidget::Start()
 	CaptureMachine->Properties = Properties;
 
 	CaptureMachine->ChangeTexture.AddDynamic(this, &UWindowCaptureWidget::OnChangeTexture);
-	return CaptureMachine->Start();
+	CaptureMachine->Start();
 }
 
 void UWindowCaptureWidget::OnChangeTexture(UTexture2D* _NewTexture)

--- a/Plugins/WindowCapture2D/Source/WindowCapture2D/Public/CaptureMachine.h
+++ b/Plugins/WindowCapture2D/Source/WindowCapture2D/Public/CaptureMachine.h
@@ -30,7 +30,7 @@ public:
 	UCaptureMachine();
 
 	UFUNCTION(BlueprintCallable, Category = WindowCapture2D)
-	virtual UTexture2D* Start();
+	virtual void Start();
 
 	UFUNCTION(BlueprintCallable, Category = WindowCapture2D)
 	virtual void Dispose();

--- a/Plugins/WindowCapture2D/Source/WindowCapture2D/Public/WCWorkerThread.h
+++ b/Plugins/WindowCapture2D/Source/WindowCapture2D/Public/WCWorkerThread.h
@@ -10,8 +10,16 @@
 class WINDOWCAPTURE2D_API FWCWorkerThread : public FRunnable
 {
 public:
+	enum class EWorkState : uint8
+	{
+		Working,
+		Stop,
+		Wait
+	};
+	
+public:
 	FWCWorkerThread(
-		const TFunction<bool()>& InWork,
+		const TFunction<EWorkState()>& InWork,
 		const TFunction<void()>& InInitialize = []() {},
 		const TFunction<void()>& InFinalize = []() {}
 	);
@@ -20,14 +28,11 @@ public:
 	virtual uint32 Run() override final;
 	virtual void Stop() override final;
 	virtual void Exit() override;
-	void WakeUp();
 
 	FThreadSafeBool ContinueRun{true};
 
 private:
-	TFunction<bool()> Work;
+	TFunction<EWorkState()> Work;
 	TFunction<void()> Initialize;
 	TFunction<void()> Finalize;
-	
-	FEvent* _waitEvent;
 };

--- a/Plugins/WindowCapture2D/Source/WindowCapture2D/Public/WindowCaptureActor.h
+++ b/Plugins/WindowCapture2D/Source/WindowCapture2D/Public/WindowCaptureActor.h
@@ -22,7 +22,7 @@ public:
 
 protected:
 	UFUNCTION(BlueprintCallable, Category = WindowCapture2D)
-	UTexture2D* Start();
+	void Start();
 
 	UFUNCTION()
 	void OnChangeTexture(UTexture2D* NewTexture);

--- a/Plugins/WindowCapture2D/Source/WindowCapture2D/Public/WindowCaptureSession.h
+++ b/Plugins/WindowCapture2D/Source/WindowCapture2D/Public/WindowCaptureSession.h
@@ -17,6 +17,7 @@
 #include "Windows/PostWindowsApi.h"
 #include "Windows/HideWindowsPlatformAtomics.h"
 #include "Windows/HideWindowsPlatformTypes.h"
+#include "WCWorkerThread.h"
 
 class WindowCaptureSession;
 
@@ -46,7 +47,7 @@ public:
 	TArray<uint8> m_buffer;
 private:
 
-	bool CaptureWork();
+	FWCWorkerThread::EWorkState CaptureWork();
 	
 	HWND m_hwnd;
 	FCriticalSection m_mutex_buffer;

--- a/Plugins/WindowCapture2D/Source/WindowCapture2D/Public/WindowCaptureWidget.h
+++ b/Plugins/WindowCapture2D/Source/WindowCapture2D/Public/WindowCaptureWidget.h
@@ -22,7 +22,7 @@ public:
 
 protected:
 	UFUNCTION(BlueprintCallable, Category = WindowCapture2D)
-	UTexture2D* Start();
+	void Start();
 
 	UFUNCTION()
 	void OnChangeTexture(UTexture2D* NewTexture);

--- a/Plugins/WindowCapture2D/Source/WindowCapture2DTests/Private/CaptureMachineTests.cpp
+++ b/Plugins/WindowCapture2D/Source/WindowCapture2DTests/Private/CaptureMachineTests.cpp
@@ -3,73 +3,110 @@
 #include "Misc/AutomationTest.h"
 #include "CaptureMachine.h"
 #include "Engine/Texture2D.h"
+#include "Tests/AutomationCommon.h"
 
 // Test: UCaptureMachine instance creation and Dispose
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FCaptureMachineBasicTest, "WindowCapture2D.CaptureMachine.BasicLifecycle", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FCaptureMachineBasicTest, "WindowCapture2D.CaptureMachine.BasicLifecycle",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
 bool FCaptureMachineBasicTest::RunTest(const FString& Parameters)
 {
-    UCaptureMachine* CaptureMachine = NewObject<UCaptureMachine>();
-    TestNotNull(TEXT("UCaptureMachine instance should be created"), CaptureMachine);
-    CaptureMachine->Dispose();
-    TestTrue(TEXT("Dispose should be called without crash"), true);
-    return true;
+	UCaptureMachine* CaptureMachine = NewObject<UCaptureMachine>();
+	TestNotNull(TEXT("UCaptureMachine instance should be created"), CaptureMachine);
+	CaptureMachine->Dispose();
+	TestTrue(TEXT("Dispose should be called without crash"), true);
+	return true;
 }
 
-// Test: CreateTexture finds window with forward match (default)
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FCaptureMachineCreateTextureTest, "WindowCapture2D.CaptureMachine.CreateTextureForwardMatch", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
-bool FCaptureMachineCreateTextureTest::RunTest(const FString& Parameters)
+// Test: TextureTarget becomes non-null within timeout
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FCaptureMachineTextureTargetSetTest,
+                                 "WindowCapture2D.CaptureMachine.TextureTargetSetWithinTimeout",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FCaptureMachineTextureTargetSetTest::RunTest(const FString& Parameters)
 {
-    UCaptureMachine* CaptureMachine = NewObject<UCaptureMachine>();
-    CaptureMachine->Properties.CaptureTargetTitle = TEXT("WindowCapture2D");
-    CaptureMachine->Properties.TitleMatchingWindowSearch = ETitleMatchingWindowSearch::ForwardMatch;
-    UTexture2D* Texture = CaptureMachine->Start();
-    TestNotNull(TEXT("Texture should not be null if window found (forward match)"), Texture);
-    CaptureMachine->Dispose();
-    return true;
+	UCaptureMachine* CaptureMachine = NewObject<UCaptureMachine>();
+	CaptureMachine->Properties.CaptureTargetTitle = TEXT("WindowCapture2D");
+	CaptureMachine->Properties.TitleMatchingWindowSearch = ETitleMatchingWindowSearch::PartialMatch;
+
+	CaptureMachine->Start();
+	
+	ADD_LATENT_AUTOMATION_COMMAND(FEngineWaitLatentCommand(3.0f));
+	
+	ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, CaptureMachine]()
+		{
+		TestNotNull(TEXT("TextureTarget should become non-null within timeout"), CaptureMachine->TextureTarget);
+		return true;}));
+
+	ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, CaptureMachine]()
+	{
+		CaptureMachine->Dispose();
+		return true; 
+	}));
+	
+	return true;
 }
 
 // Test: CreateTexture fails when window is not found
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FCaptureMachineCreateTextureNotFoundTest, "WindowCapture2D.CaptureMachine.CreateTextureNotFound", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FCaptureMachineCreateTextureNotFoundTest,
+                                 "WindowCapture2D.CaptureMachine.CreateTextureNotFound",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
 bool FCaptureMachineCreateTextureNotFoundTest::RunTest(const FString& Parameters)
 {
-    UCaptureMachine* CaptureMachine = NewObject<UCaptureMachine>();
-    CaptureMachine->Properties.CaptureTargetTitle = TEXT("DefinitelyNotExistWindowTitle");
-    CaptureMachine->Properties.TitleMatchingWindowSearch = ETitleMatchingWindowSearch::PerfectMatch;
-    UTexture2D* Texture = CaptureMachine->Start();
-    TestNull(TEXT("Texture should be null if window not found"), Texture);
-    CaptureMachine->Dispose();
-    return true;
+	UCaptureMachine* CaptureMachine = NewObject<UCaptureMachine>();
+	CaptureMachine->Properties.CaptureTargetTitle = TEXT("DefinitelyNotExistWindowTitle");
+	CaptureMachine->Properties.TitleMatchingWindowSearch = ETitleMatchingWindowSearch::PerfectMatch;
+	CaptureMachine->Start();
+
+	ADD_LATENT_AUTOMATION_COMMAND(FEngineWaitLatentCommand(3.0f));
+	
+	ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, CaptureMachine]()
+		{
+		TestNull(TEXT("Texture should be null if window not found"), CaptureMachine->TextureTarget);
+		return true;}));
+
+	ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, CaptureMachine]()
+	{
+		CaptureMachine->Dispose();
+		return true; 
+	}));
+	
+	return true;
 }
 
 // Test: FindTargetWindow matching patterns
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FCaptureMachineFindTargetWindowTest, "WindowCapture2D.CaptureMachine.FindTargetWindowPatterns", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FCaptureMachineFindTargetWindowTest,
+                                 "WindowCapture2D.CaptureMachine.FindTargetWindowPatterns",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
 bool FCaptureMachineFindTargetWindowTest::RunTest(const FString& Parameters)
 {
-    UCaptureMachine* CaptureMachine = NewObject<UCaptureMachine>();
-    HWND DummyHwnd = nullptr; // NOTE: Replace this with a valid HWND in integration test
-    
-    // Test for each matching type
-    CaptureMachine->Properties.CaptureTargetTitle = TEXT("WindowCapture2D");
-    CaptureMachine->Properties.TitleMatchingWindowSearch = ETitleMatchingWindowSearch::PerfectMatch;
-    CaptureMachine->Start();
-    
-    bool resultPerfect = CaptureMachine->FindTargetWindow(DummyHwnd);
-    CaptureMachine->Properties.TitleMatchingWindowSearch = ETitleMatchingWindowSearch::ForwardMatch;
-    bool resultForward = CaptureMachine->FindTargetWindow(DummyHwnd);
-    CaptureMachine->Properties.TitleMatchingWindowSearch = ETitleMatchingWindowSearch::PartialMatch;
-    bool resultPartial = CaptureMachine->FindTargetWindow(DummyHwnd);
-    CaptureMachine->Properties.TitleMatchingWindowSearch = ETitleMatchingWindowSearch::BackwardMatch;
-    bool resultBackward = CaptureMachine->FindTargetWindow(DummyHwnd);
-    CaptureMachine->Properties.TitleMatchingWindowSearch = ETitleMatchingWindowSearch::RegularExpression;
-    
-    bool resultRegex = CaptureMachine->FindTargetWindow(DummyHwnd);
-    // For dummy HWND, all should be true (not found)
-    TestTrue(TEXT("PerfectMatch should return true for dummy hwnd"), resultPerfect);
-    TestTrue(TEXT("ForwardMatch should return true for dummy hwnd"), resultForward);
-    TestTrue(TEXT("PartialMatch should return true for dummy hwnd"), resultPartial);
-    TestTrue(TEXT("BackwardMatch should return true for dummy hwnd"), resultBackward);
-    TestTrue(TEXT("RegularExpression should return true for dummy hwnd"), resultRegex);
-    CaptureMachine->Dispose();
-    return true;
+	UCaptureMachine* CaptureMachine = NewObject<UCaptureMachine>();
+	HWND DummyHwnd = nullptr; // NOTE: Replace this with a valid HWND in integration test
+
+	// Test for each matching type
+	CaptureMachine->Properties.CaptureTargetTitle = TEXT("WindowCapture2D");
+	CaptureMachine->Properties.TitleMatchingWindowSearch = ETitleMatchingWindowSearch::PartialMatch;
+	CaptureMachine->Start();
+
+	bool resultPerfect = CaptureMachine->FindTargetWindow(DummyHwnd);
+	CaptureMachine->Properties.TitleMatchingWindowSearch = ETitleMatchingWindowSearch::ForwardMatch;
+	bool resultForward = CaptureMachine->FindTargetWindow(DummyHwnd);
+	CaptureMachine->Properties.TitleMatchingWindowSearch = ETitleMatchingWindowSearch::PartialMatch;
+	bool resultPartial = CaptureMachine->FindTargetWindow(DummyHwnd);
+	CaptureMachine->Properties.TitleMatchingWindowSearch = ETitleMatchingWindowSearch::BackwardMatch;
+	bool resultBackward = CaptureMachine->FindTargetWindow(DummyHwnd);
+	CaptureMachine->Properties.TitleMatchingWindowSearch = ETitleMatchingWindowSearch::RegularExpression;
+
+	bool resultRegex = CaptureMachine->FindTargetWindow(DummyHwnd);
+	// For dummy HWND, all should be true (not found)
+	TestTrue(TEXT("PerfectMatch should return true for dummy hwnd"), resultPerfect);
+	TestTrue(TEXT("ForwardMatch should return true for dummy hwnd"), resultForward);
+	TestTrue(TEXT("PartialMatch should return true for dummy hwnd"), resultPartial);
+	TestTrue(TEXT("BackwardMatch should return true for dummy hwnd"), resultBackward);
+	TestTrue(TEXT("RegularExpression should return true for dummy hwnd"), resultRegex);
+	CaptureMachine->Dispose();
+	return true;
 }
 #endif


### PR DESCRIPTION
When WinRT initialization was done in the main thread and window capture was done in the worker thread, there was a problem with certain PCs (probably Windows 10) not being able to capture.

So I changed it so that the WinRT object is touched only from within the worker thread.