### PR TITLE
Fix winrt thread error

### DIFF
--- a/Plugins/WindowCapture2D/Source/WindowCapture2D/Private/WindowCaptureSession.cpp
+++ b/Plugins/WindowCapture2D/Source/WindowCapture2D/Private/WindowCaptureSession.cpp
@@ -43,7 +43,7 @@ bool WindowCaptureSession::GetFrameInfo(WCFrameDesc* OutDesc) const
 {
 	if (m_captureItem)
 	{
-		auto size = m_captureItem.Size();
+		auto size = m_captureSize;
 		OutDesc->width = size.Width;
 		OutDesc->height = size.Height;
 		OutDesc->stride = size.Width * 4;
@@ -127,6 +127,7 @@ void WindowCaptureSession::InitializeWinRTCaptureResources()
 	const auto session = framePool.CreateCaptureSession(item);
 
 	m_captureItem = item;
+	m_captureSize = item.Size();
 	m_framePool = framePool;
 	m_session = session;
 
@@ -156,8 +157,7 @@ FWCWorkerThread::EWorkState WindowCaptureSession::CaptureWork()
 
 		if (m_captureItem)
 		{
-			auto itemSize = m_captureItem.Size();
-			if (itemSize.Width != static_cast<int>(desc.Width) || itemSize.Height != static_cast<int>(desc.Height))
+			if (m_captureSize.Width != static_cast<int>(desc.Width) || m_captureSize.Height != static_cast<int>(desc.Height))
 			{
 				m_frameArrivedRevoker.revoke();
 				m_framePool.Close();
@@ -308,6 +308,7 @@ void WindowCaptureSession::Stop()
 	m_session = nullptr;
 	m_framePool = nullptr;
 	m_captureItem = nullptr;
+	m_captureSize = {};
 	m_d3dDevice = nullptr;
 	m_d3dContext = nullptr;
 	m_stagingTexture = nullptr;	

--- a/Plugins/WindowCapture2D/Source/WindowCapture2D/Private/WindowCaptureSession.cpp
+++ b/Plugins/WindowCapture2D/Source/WindowCapture2D/Private/WindowCaptureSession.cpp
@@ -157,6 +157,7 @@ FWCWorkerThread::EWorkState WindowCaptureSession::CaptureWork()
 
 		if (m_captureItem)
 		{
+			m_captureSize = m_captureItem.Size();
 			if (m_captureSize.Width != static_cast<int>(desc.Width) || m_captureSize.Height != static_cast<int>(desc.Height))
 			{
 				m_framePool.Close();
@@ -249,10 +250,16 @@ int WindowCaptureSession::Start(HWND hWnd)
             InitializeWinRTCaptureResources();
 		},
 		[this]() {
+			if (m_session)
+			{
+				m_session.Close();
+			}
+			
 			if (m_framePool)
 			{
 				m_framePool.Close();
-			}		
+			}
+			
 			m_session = nullptr;
 			m_framePool = nullptr;
 			m_captureItem = nullptr;
@@ -297,11 +304,6 @@ void WindowCaptureSession::Stop()
 		{
 			delete m_workerThread;
 			m_workerThread = nullptr;
-		}
-
-		if (m_session)
-		{
-			m_session.Close();
 		}
 	}
 	catch (...)

--- a/Plugins/WindowCapture2D/Source/WindowCapture2D/Public/WindowCaptureSession.h
+++ b/Plugins/WindowCapture2D/Source/WindowCapture2D/Public/WindowCaptureSession.h
@@ -69,7 +69,6 @@ private:
 	winrt::Windows::Graphics::Capture::GraphicsCaptureItem m_captureItem{nullptr};
 	winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool m_framePool{nullptr};
 	winrt::Windows::Graphics::Capture::GraphicsCaptureSession m_session{nullptr};
-	winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool::FrameArrived_revoker m_frameArrivedRevoker;
 
 	winrt::Windows::Graphics::SizeInt32 m_captureSize = {};
 

--- a/Plugins/WindowCapture2D/Source/WindowCapture2D/Public/WindowCaptureSession.h
+++ b/Plugins/WindowCapture2D/Source/WindowCapture2D/Public/WindowCaptureSession.h
@@ -71,6 +71,8 @@ private:
 	winrt::Windows::Graphics::Capture::GraphicsCaptureSession m_session{nullptr};
 	winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool::FrameArrived_revoker m_frameArrivedRevoker;
 
+	winrt::Windows::Graphics::SizeInt32 m_captureSize = {};
+
 
 	void InitializeCaptureResources();
 	void InitializeWinRTCaptureResources();


### PR DESCRIPTION
Changed WinRT objects to be completely untouched from the main thread.

This was necessary to get the plugin to work on Windows 10.